### PR TITLE
add paramter expectations to mixins

### DIFF
--- a/lib/stylus-mixins/ie.styl
+++ b/lib/stylus-mixins/ie.styl
@@ -32,6 +32,7 @@
 
 
 ie($version, $strict = false)
+  require-unit($version)
   if ($is-ie == true)
     if($strict == true)
       if ($is-ie--version == $version)

--- a/lib/stylus-mixins/media/width-height.styl
+++ b/lib/stylus-mixins/media/width-height.styl
@@ -14,14 +14,18 @@ $width--fixed-max ?= 1200px
 //
 
 width-min($a)
+  require-unit($a)
   +_media('width', 'min', $a)
     {block}
 
 width-max($a)
+  require-unit($a)
   +_media('width', 'max', $a)
     {block}
 
 width-range($a, $b)
+  require-unit($a)
+  require-unit($b)
   +_media('width', 'range', $a, $b)
     {block}
 
@@ -31,14 +35,18 @@ width-range($a, $b)
 //
 
 height-min($a)
+  require-unit($a)
   +_media('height', 'min', $a)
     {block}
 
 height-max($a)
+  require-unit($a)
   +_media('height', 'max', $a)
     {block}
 
 height-range($a, $b)
+  require-unit($a)
+  require-unit($b)
   +_media('height', 'range', $a, $b)
     {block}
 

--- a/lib/stylus-mixins/text/font-face.styl
+++ b/lib/stylus-mixins/text/font-face.styl
@@ -11,6 +11,8 @@
 //
 
 font-face($name, $filepath, $weight = 'normal', $style = 'normal')
+  require-string($name)
+  require-string($filepath)
 
   $url-fallback = 'url("' + $filepath + '.eot")'
   $url  = 'url("' + $filepath + '.eot?#iefix") format("embedded-opentype"), '

--- a/lib/stylus-mixins/unit-mixins.styl
+++ b/lib/stylus-mixins/unit-mixins.styl
@@ -11,6 +11,7 @@
 //
 
 em($px, $base = $baseFontSize)
+  require-unit($px)
   ($px / $base) em
 
 
@@ -20,4 +21,6 @@ em($px, $base = $baseFontSize)
 //
 
 ratio-percentage(a, b)
+  require-unit(a)
+  require-unit(b)
   ( b / a  * 100 ) %


### PR DESCRIPTION
I saw this being used in stylus core (https://github.com/LearnBoost/stylus/blob/master/lib/functions/index.styl) to make sure that the variables being passed to their mixins where the right type. I figured it would be good to have that in stylus-mixins. 

If, say, ie('string') was used, the compiler will bring back a message telling the person that $version was expecting to be a unit, not a string. I don't think I can make the below any prettier though.

```
     Error: ../stylus-mixins/node_modules/stylus-test-runner/node_modules/stylus/lib/functions/index.styl:19
   15| 
   16| require-unit(n)
   17|   unless n is a 'unit'
   18|     error('unit expected, got a ' + -string(n))
 > 19| 
   20| // require a string
   21| 
   22| require-string(str)

unit expected, got a string test
    at require-unit() (/private/var/application/Clock/Internal/stylus-mixins/node_modules/stylus-test-runner/node_modules/stylus/lib/functions/index.styl:17)
    at ie() (/private/var/application/Clock/Internal/stylus-mixins/lib/stylus-mixins/ie.styl:38)
    at ".class" (stylus:11)
```
