### PR TITLE
col-span-width() mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Documentation for each mixin can be found in the [docs directory](https://github
 
 **Helpers**
 * [Timing Function Variables](https://github.com/jackbrewer/stylus-mixins/blob/master/docs/helpers/timing-functions.md) - Cubic Bezier values for common easing functions
+* [Column Span Width](https://github.com/jackbrewer/stylus-mixins/blob/master/docs/helpers/col-span-width.md) - col-span-width()
 
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Documentation for each mixin can be found in the [docs directory](https://github
 * [Tracking](https://github.com/jackbrewer/stylus-mixins/blob/master/docs/units/tracking.md) - tracking()
 
 **Helpers**
-* [Timing Function Variables](https://github.com/jackbrewer/stylus-mixins/blob/master/docs/helpers/timing-functions.md) - Cubic Bezier values for common easing functions
 * [Column Span Width](https://github.com/jackbrewer/stylus-mixins/blob/master/docs/helpers/col-span-width.md) - col-span-width()
+* [Timing Function Variables](https://github.com/jackbrewer/stylus-mixins/blob/master/docs/helpers/timing-functions.md) - Cubic Bezier values for common easing functions
 
 
 ## Running Tests

--- a/docs/helpers/col-span-width.md
+++ b/docs/helpers/col-span-width.md
@@ -1,18 +1,18 @@
 # Column Span Width
 
 ```css
-col-span-width($col-span, [$col-total], [$grid-gutter], [$max-width])
+col-span-width($col-span, [$col-total], [$col-gutter], [$max-width])
 ```
 
-Returns the width of a specified column span, based on a grid column total, grid-gutter and max-width.
-The same unit type should be used for the grid-gutter and max-width, as that is what the returned width will use.
+Returns the width of a specified column span, based on a column total, column gutter and max-width.
+The same unit type should be used for the column gutter and max-width, as that is what the returned width will use.
 
 ```css
 $col-total = 12
 $grid--gutter ?= 20px
 $base--max-width ?= 1180px
 ```
-* Default values are provided for column total, grid-gutter and max-width making them optional.
+* Default values are provided for column total, column gutter and max-width making them optional.
 * Use these variables within a project to set custom values.
 
 ---
@@ -28,7 +28,7 @@ $base--max-width ?= 1180px
 }
 ```
 
-**Example - custom column total, grid-gutter and max-width**
+**Example - custom column total, column gutter and max-width**
 
 ```css
 .element

--- a/docs/helpers/col-span-width.md
+++ b/docs/helpers/col-span-width.md
@@ -1,0 +1,45 @@
+# Column Span Width
+
+```css
+col-span-width($col-span, [$col-total], [$grid-gutter], [$max-width])
+```
+
+Returns the width of a specified column span, based on a grid column total, grid-gutter and max-width.
+The same unit type should be used for the grid-gutter and max-width, as that is what the returned width will use.
+
+```css
+$col-total = 12
+$grid--gutter ?= 20px
+$base--max-width ?= 1180px
+```
+* Default values are provided for column total, grid-gutter and max-width making them optional.
+* Use these variables within a project to set custom values.
+
+---
+
+**Example – single value**
+```css
+.element
+  max-width col-span-width(4)
+
+/* CSS */
+.element {
+  max-width: 380px;
+}
+```
+
+**Example - custom column total, grid-gutter and max-width**
+
+```css
+.element
+  width col-span-width(5, 10, 2rem, 80rem)
+
+/* CSS */
+.element {
+  width: 39rem;
+}
+```
+
+---
+
+[Source](https://github.com/jackbrewer/stylus-mixins/blob/master/lib/stylus-mixins/helpers/col-span-width.styl) - [Tests](https://github.com/jackbrewer/stylus-mixins/blob/master/test/tests/helpers/col-span-width.styl)

--- a/lib/stylus-mixins/helpers/col-span-width.styl
+++ b/lib/stylus-mixins/helpers/col-span-width.styl
@@ -1,0 +1,11 @@
+//
+// COLUMN SPAN WIDTH
+// =================
+// Returns the width of a specified column span
+//
+
+$grid--gutter ?= 20px
+$base--max-width ?= 1200px
+
+col-span-width($col-span, $col-total = 12, $grid-gutter = $grid--gutter, $max-width = $base--max-width)
+  ($max-width + $grid-gutter) * $col-span / $col-total - $grid-gutter

--- a/lib/stylus-mixins/helpers/col-span-width.styl
+++ b/lib/stylus-mixins/helpers/col-span-width.styl
@@ -7,5 +7,5 @@
 $grid--gutter ?= 20px
 $base--max-width ?= 1200px
 
-col-span-width($col-span, $col-total = 12, $grid-gutter = $grid--gutter, $max-width = $base--max-width)
-  ($max-width + $grid-gutter) * $col-span / $col-total - $grid-gutter
+col-span-width($col-span, $col-total = 12, $col-gutter = $grid--gutter, $max-width = $base--max-width)
+  ($max-width + $col-gutter) * $col-span / $col-total - $col-gutter

--- a/lib/stylus-mixins/index.styl
+++ b/lib/stylus-mixins/index.styl
@@ -19,8 +19,8 @@
 // HELPERS
 //
 
-@import 'helpers/timing-functions'
 @import 'helpers/col-span-width'
+@import 'helpers/timing-functions'
 
 
 //

--- a/lib/stylus-mixins/index.styl
+++ b/lib/stylus-mixins/index.styl
@@ -20,6 +20,7 @@
 //
 
 @import 'helpers/timing-functions'
+@import 'helpers/col-span-width'
 
 
 //

--- a/test/tests/helpers/col-span-width.styl
+++ b/test/tests/helpers/col-span-width.styl
@@ -1,0 +1,22 @@
+// @describe col-span-width()
+
+// @it output width of a defined column span as px
+$grid--gutter = 20px
+$base--max-width = 1180px
+
+.foo
+  max-width col-span-width(4)
+
+// @expect
+.foo {
+  max-width: 380px;
+}
+
+// @it output width of a defined column span as rem, with custom gutter and grid width
+.foo
+  max-width col-span-width(5, 10, 2rem, 80rem)
+
+// @expect
+.foo {
+  max-width: 39rem;
+}


### PR DESCRIPTION
Adds `col-span-width()` mixin. Includes tests and documentation.

`col-span-width()` returns the width of a specified column span, based on a column total, column gutter and max-width.