### PR TITLE
Appends a trimmed font-name to the svg file path

### DIFF
--- a/lib/stylus-mixins/text/font-face.styl
+++ b/lib/stylus-mixins/text/font-face.styl
@@ -10,7 +10,7 @@ font-face($font-name, $file-path, $weight = 'normal', $style = 'normal')
   $url  = 'url("' + $file-path + '.eot?#iefix") format("embedded-opentype"), '
   $url = $url + 'url("' + $file-path + '.woff") format("woff"), '
   $url = $url + 'url("' + $file-path + '.ttf") format("truetype"), '
-  $url = $url + 'url("' + $file-path + '.svg#svg' + $font-name + '") format("svg")'
+  $url = $url + 'url("' + $file-path + '.svg#svg' + replace(' ', '', $font-name) + '") format("svg")'
 
   @font-face
     font-family $font-name

--- a/test/tests/text/font-face.styl
+++ b/test/tests/text/font-face.styl
@@ -1,11 +1,11 @@
 // @describe font-face()
 
 // @it should output @fontface with name and filepath
-font-face('FontName', '/fonts/font-name')
+font-face("Font Name", '/fonts/font-name')
 
 // @expect
 @font-face {
-  font-family: "FontName";
+  font-family: "Font Name";
   src: url("/fonts/font-name.eot");
   src: url("/fonts/font-name.eot?#iefix") format("embedded-opentype"), url("/fonts/font-name.woff") format("woff"), url("/fonts/font-name.ttf") format("truetype"), url("/fonts/font-name.svg#svgFontName") format("svg");
   font-weight: 400;
@@ -13,11 +13,11 @@ font-face('FontName', '/fonts/font-name')
 }
 
 // @it should output optional custom weight and style parameters
-font-face('FontName', '/fonts/font-name', 'bold', 'italic')
+font-face("Font Name", '/fonts/font-name', 'bold', 'italic')
 
 // @expect
 @font-face {
-  font-family: "FontName";
+  font-family: "Font Name";
   src: url("/fonts/font-name.eot");
   src: url("/fonts/font-name.eot?#iefix") format("embedded-opentype"), url("/fonts/font-name.woff") format("woff"), url("/fonts/font-name.ttf") format("truetype"), url("/fonts/font-name.svg#svgFontName") format("svg");
   font-weight: bold;


### PR DESCRIPTION
If a font's name contains spaces like 'Helvetica Neue', it would be appended to the svg file path '#Helvetica Neue' instead of '#HelveticaNeue'.

I just added a replace/trim function to the mixin. 
